### PR TITLE
Fix frame rendering for hls nodes when renderNodeOnDemandOnly flag is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.57.4",
+  "version": "0.57.5",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/SourceNodes/hlsnode.ts
+++ b/src/SourceNodes/hlsnode.ts
@@ -89,8 +89,10 @@ export class HLSNode extends MediaNode {
         if (this._state === SOURCENODESTATE.sequenced || this._state === SOURCENODESTATE.waiting) {
             return true;
         }
+        const isActiveNode =
+            this._currentTime <= this._stopTime && this._currentTime >= this._startTime;
 
-        if (this._isElementPlaying) {
+        if (isActiveNode) {
             return super._isReady();
         }
 


### PR DESCRIPTION
Current issue: when `renderNodeOnDemandOnly` is `true` and we change **currentTime** the new frames are not rendered to the _canvas_

when `renderNodeOnDemandOnly` is set to **true** we need to make sure a node has content
to display before we attempt to render it to the canvas, we are checking the nodes state with `const ready = !this._isStalled();` https://github.com/alanjrogers/VideoContext/blob/develop/src/videocontext.ts#L1119

So I updated the **his** node `_isReady` method to take into account the active nodes and not only the playing one since we need this check when VideoContext is in Pause state too,
this change will also work when playing since we only want the buffer check on the current active node.

