### PR TITLE
Set the startLevel in every call to _load

### DIFF
--- a/src/SourceNodes/hlsnode.ts
+++ b/src/SourceNodes/hlsnode.ts
@@ -77,12 +77,12 @@ export class HLSNode extends MediaNode {
 
             this._loaded = true;
             this._hlsLoading = true;
-            this._hls.startLevel = this._hls.levels.length - 1;
         } else if (!this._hlsLoading) {
             this._hls.loadSource(this._src);
             this._hlsLoading = true;
         }
         super._load();
+        this._hls.startLevel = this._hls.levels.length - 1;
     }
 
     _isReady() {


### PR DESCRIPTION
I think we were doing it too early before, but also this is probably overkill... We should circle back and find the right place to call this, perhaps in a callback from when hls has loaded the available levels?