### PR TITLE
HLS Node - only set startLevel if new levels are available

### DIFF
--- a/src/SourceNodes/hlsnode.ts
+++ b/src/SourceNodes/hlsnode.ts
@@ -82,7 +82,9 @@ export class HLSNode extends MediaNode {
             this._hlsLoading = true;
         }
         super._load();
-        this._hls.startLevel = this._hls.levels.length - 1;
+        if (this._hls.startLevel !== this._hls.levels.length - 1) {
+            this._hls.startLevel = this._hls.levels.length - 1;
+        }
     }
 
     _isReady() {


### PR DESCRIPTION
`_load` function is executed each RAF setting repeated start Level values

![set level2](https://github.com/alanjrogers/VideoContext/assets/11876080/3b285252-2c91-4c68-83ad-56344d9ded76)

Changes:
- only set startLevel if new levels are available