### PR TITLE
Set load level to max when the manifest loads and not on every _load …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.57.8",
+  "version": "0.57.9",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/SourceNodes/hlsnode.ts
+++ b/src/SourceNodes/hlsnode.ts
@@ -56,7 +56,8 @@ export class HLSNode extends MediaNode {
             backBufferLength: duration
         });
 
-        this._hls.on(Hls.Events.MANIFEST_LOADED, () => {
+        // LEVEL_LOADED is fired when a level playlist loading finishes - data: { details : levelDetails object, level : id of loaded level, stats : LoaderStats }
+        this._hls.on(Hls.Events.LEVEL_LOADED, () => {
             this._hls.startLevel = this._hls.levels.length - 1;
             this._hls.currentLevel = this._hls.levels.length - 1;
         });
@@ -121,7 +122,7 @@ export class HLSNode extends MediaNode {
         this._hlsLoading = false;
 
         if (this._hls) {
-            this._hls.off(Hls.Events.MANIFEST_LOADED);
+            this._hls.off(Hls.Events.LEVEL_LOADED);
             this._hls.destroy();
         }
         super.destroy();

--- a/src/SourceNodes/hlsnode.ts
+++ b/src/SourceNodes/hlsnode.ts
@@ -56,6 +56,11 @@ export class HLSNode extends MediaNode {
             backBufferLength: duration
         });
 
+        this._hls.on(Hls.Events.MANIFEST_LOADED, () => {
+            this._hls.startLevel = this._hls.levels.length - 1;
+            this._hls.currentLevel = this._hls.levels.length - 1;
+        });
+
         //Set the source path.
         this._id = id;
         this._src = src;
@@ -82,9 +87,6 @@ export class HLSNode extends MediaNode {
             this._hlsLoading = true;
         }
         super._load();
-        if (this._hls.startLevel !== this._hls.levels.length - 1) {
-            this._hls.startLevel = this._hls.levels.length - 1;
-        }
     }
 
     _isReady() {
@@ -119,6 +121,7 @@ export class HLSNode extends MediaNode {
         this._hlsLoading = false;
 
         if (this._hls) {
+            this._hls.off(Hls.Events.MANIFEST_LOADED);
             this._hls.destroy();
         }
         super.destroy();

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -150,7 +150,7 @@ export default class VideoContext {
         this._renderNodeOnDemandOnly = renderNodeOnDemandOnly;
 
         this._gl = canvas.getContext(
-            "webgl",
+            "experimental-webgl",
             Object.assign(
                 { preserveDrawingBuffer: true }, // can be overriden
                 webglContextAttributes,


### PR DESCRIPTION
- Don't call startLevel in _load continuously.
- Call it when the manifest has loaded and also set currentLevel.