### PR TITLE
add property to allow change background color to scale fragment shader 

### DIFF
--- a/src/Definitions/aaf_video_scale/aaf_video_scale.frag
+++ b/src/Definitions/aaf_video_scale/aaf_video_scale.frag
@@ -2,13 +2,14 @@ precision mediump float;
 uniform sampler2D u_image;
 uniform float scaleX;
 uniform float scaleY;
+uniform vec4 bColor;
 varying vec2 v_texCoord;
 varying float v_progress;
 void main(){
     vec2 pos = vec2(v_texCoord[0]*1.0/scaleX - (1.0/scaleX/2.0 -0.5), v_texCoord[1]*1.0/scaleY - (1.0/scaleY/2.0 -0.5));
     vec4 color = texture2D(u_image, pos);
     if (pos[0] < 0.0 || pos[0] > 1.0 || pos[1] < 0.0 || pos[1] > 1.0){
-        color = vec4(0.0,0.0,0.0,0.0);
+        color = bColor;
     }
     gl_FragColor = color;
 }

--- a/src/Definitions/aaf_video_scale/aaf_video_scale.js
+++ b/src/Definitions/aaf_video_scale/aaf_video_scale.js
@@ -8,7 +8,8 @@ let aaf_video_scale = {
     fragmentShader,
     properties: {
         scaleX: { type: "uniform", value: 1.0 },
-        scaleY: { type: "uniform", value: 1.0 }
+        scaleY: { type: "uniform", value: 1.0 },
+        bColor: { type: "uniform", value: [0.0, 0.0, 0.0, 0.0]}
     },
     inputs: ["u_image"]
 };


### PR DESCRIPTION
To support extending a scene duration we need to add a temporary node before or after the current scene to be able to show the correct frame on the player while the user is actively extending the node duration.
When adding the temporary node that is scaled we need to be able to set the background to a solid color to avoid a transparent background on overlapping nodes:
