### PR TITLE
MediaNodes are ready when they have future data!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.58.1",
+  "version": "0.58.2",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/SourceNodes/medianode.ts
+++ b/src/SourceNodes/medianode.ts
@@ -187,7 +187,10 @@ class MediaNode extends SourceNode {
          * it gets called a lot of time
          */
         if (shouldPollForElementReadyState) {
-            if (this._element!.readyState > 3 && !this._element!.seeking) {
+            if (
+                this._element!.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA &&
+                !this._element!.seeking
+            ) {
                 // at this point the element has enough data for current playback position
                 // and at least a couple of frames into the future
 


### PR DESCRIPTION
Based on the comment below this looks like it was unintentionally marking a media node as ready ONLY when it was fully buffered.