### PR TITLE
Upgrade to webgl2 and additional seeking, seeked events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/Definitions/aaf_video_scale/aaf_video_scale.frag
+++ b/src/Definitions/aaf_video_scale/aaf_video_scale.frag
@@ -1,15 +1,17 @@
+#version 300 es
+
 precision mediump float;
 uniform sampler2D u_image;
 uniform float scaleX;
 uniform float scaleY;
 uniform vec4 bColor;
-varying vec2 v_texCoord;
-varying float v_progress;
-void main(){
-    vec2 pos = vec2(v_texCoord[0]*1.0/scaleX - (1.0/scaleX/2.0 -0.5), v_texCoord[1]*1.0/scaleY - (1.0/scaleY/2.0 -0.5));
-    vec4 color = texture2D(u_image, pos);
-    if (pos[0] < 0.0 || pos[0] > 1.0 || pos[1] < 0.0 || pos[1] > 1.0){
-        color = bColor;
+in vec2 v_texCoord;
+out vec4 outColor;
+
+void main() {
+    vec2 pos = vec2(v_texCoord[0] * 1.0f / scaleX - (1.0f / scaleX / 2.0f - 0.5f), v_texCoord[1] * 1.0f / scaleY - (1.0f / scaleY / 2.0f - 0.5f));
+    outColor = texture(u_image, pos);
+    if(pos[0] < 0.0f || pos[0] > 1.0f || pos[1] < 0.0f || pos[1] > 1.0f) {
+        outColor = bColor;
     }
-    gl_FragColor = color;
 }

--- a/src/Definitions/aaf_video_scale/aaf_video_scale.vert
+++ b/src/Definitions/aaf_video_scale/aaf_video_scale.vert
@@ -1,7 +1,10 @@
-attribute vec2 a_position;
-attribute vec2 a_texCoord;
-varying vec2 v_texCoord;
+#version 300 es
+
+in vec2 a_position;
+in vec2 a_texCoord;
+out vec2 v_texCoord;
+
 void main() {
-    gl_Position = vec4(vec2(2.0,2.0)*a_position-vec2(1.0, 1.0), 0.0, 1.0);
+    gl_Position = vec4(vec2(2.0f, 2.0f) * a_position - vec2(1.0f, 1.0f), 0.0f, 1.0f);
     v_texCoord = a_texCoord;
 }

--- a/src/Definitions/combine/combine.frag
+++ b/src/Definitions/combine/combine.frag
@@ -1,9 +1,10 @@
+#version 300 es
+
 precision mediump float;
 uniform sampler2D u_image;
-uniform float a;
-varying vec2 v_texCoord;
-varying float v_mix;
-void main(){
-    vec4 color = texture2D(u_image, v_texCoord);
-    gl_FragColor = color;
+in vec2 v_texCoord;
+
+out vec4 outColor;
+void main() {
+    outColor = texture(u_image, v_texCoord);
 }

--- a/src/Definitions/combine/combine.vert
+++ b/src/Definitions/combine/combine.vert
@@ -1,7 +1,9 @@
-attribute vec2 a_position;
-attribute vec2 a_texCoord;
-varying vec2 v_texCoord;
+#version 300 es
+
+in vec2 a_position;
+in vec2 a_texCoord;
+out vec2 v_texCoord;
 void main() {
-    gl_Position = vec4(vec2(2.0,2.0)*a_position-vec2(1.0, 1.0), 0.0, 1.0);
+    gl_Position = vec4(vec2(2.0f, 2.0f) * a_position - vec2(1.0f, 1.0f), 0.0f, 1.0f);
     v_texCoord = a_texCoord;
 }

--- a/src/DestinationNode/destinationnode.ts
+++ b/src/DestinationNode/destinationnode.ts
@@ -33,8 +33,6 @@ class DestinationNode extends ProcessingNode {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
         gl.enable(gl.BLEND);
-        gl.clearColor(0, 0, 0, 0.0);
-        gl.clear(gl.COLOR_BUFFER_BIT);
 
         this.inputs.forEach((node) => {
             super._render();

--- a/src/DestinationNode/destinationnode.ts
+++ b/src/DestinationNode/destinationnode.ts
@@ -15,7 +15,7 @@ class DestinationNode extends ProcessingNode {
      *
      * You should not instantiate this directly.
      */
-    constructor(gl: WebGLRenderingContext, renderGraph: RenderGraph) {
+    constructor(gl: WebGL2RenderingContext, renderGraph: RenderGraph) {
         let definition = {
             fragmentShader,
             vertexShader,
@@ -33,7 +33,7 @@ class DestinationNode extends ProcessingNode {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
         gl.enable(gl.BLEND);
-        gl.clearColor(0, 0, 0, 0.0); // green;
+        gl.clearColor(0, 0, 0, 0.0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         this.inputs.forEach((node) => {

--- a/src/ProcessingNodes/compositingnode.ts
+++ b/src/ProcessingNodes/compositingnode.ts
@@ -12,7 +12,7 @@ class CompositingNode extends ProcessingNode {
     /**
      * Initialise an instance of a Compositing Node. You should not instantiate this directly, but use VideoContest.createCompositingNode().
      */
-    constructor(gl: WebGLRenderingContext, renderGraph: RenderGraph, definition: IDefinition) {
+    constructor(gl: WebGL2RenderingContext, renderGraph: RenderGraph, definition: IDefinition) {
         const placeholderTexture = createElementTexture(gl);
         gl.texImage2D(
             gl.TEXTURE_2D,
@@ -40,7 +40,7 @@ class CompositingNode extends ProcessingNode {
             this._texture,
             0
         );
-        gl.clearColor(0, 0, 0, 0); // green;
+        gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 

--- a/src/ProcessingNodes/effectnode.ts
+++ b/src/ProcessingNodes/effectnode.ts
@@ -12,8 +12,8 @@ class EffectNode extends ProcessingNode {
     /**
      * Initialise an instance of an EffectNode. You should not instantiate this directly, but use VideoContest.createEffectNode().
      */
-    constructor(gl: WebGLRenderingContext, renderGraph: RenderGraph, definition: IDefinition) {
-        let placeholderTexture = createElementTexture(gl);
+    constructor(gl: WebGL2RenderingContext, renderGraph: RenderGraph, definition: IDefinition) {
+        const placeholderTexture = createElementTexture(gl);
         gl.texImage2D(
             gl.TEXTURE_2D,
             0,
@@ -42,7 +42,7 @@ class EffectNode extends ProcessingNode {
             this._texture,
             0
         );
-        gl.clearColor(0, 0, 0, 0); // green;
+        gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.blendFunc(gl.ONE, gl.ZERO);
 

--- a/src/ProcessingNodes/processingnode.ts
+++ b/src/ProcessingNodes/processingnode.ts
@@ -31,7 +31,7 @@ class ProcessingNode extends GraphNode {
      * This class is not used directly, but is extended to create CompositingNodes, TransitionNodes, and EffectNodes.
      */
     constructor(
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         definition: IDefinition,
         inputNames: string[],

--- a/src/ProcessingNodes/processingnode.ts
+++ b/src/ProcessingNodes/processingnode.ts
@@ -224,7 +224,6 @@ class ProcessingNode extends GraphNode {
     }
 
     _render() {
-        this._rendered = true;
         let gl = this._gl;
         gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
 

--- a/src/ProcessingNodes/transitionnode.ts
+++ b/src/ProcessingNodes/transitionnode.ts
@@ -19,7 +19,7 @@ class TransitionNode extends EffectNode {
     /**
      * Initialise an instance of a TransitionNode. You should not instantiate this directly, but use VideoContest.createTransitonNode().
      */
-    constructor(gl: WebGLRenderingContext, renderGraph: RenderGraph, definition: IDefinition) {
+    constructor(gl: WebGL2RenderingContext, renderGraph: RenderGraph, definition: IDefinition) {
         super(gl, renderGraph, definition);
         this._transitions = {};
 

--- a/src/SourceNodes/canvasnode.ts
+++ b/src/SourceNodes/canvasnode.ts
@@ -11,7 +11,7 @@ class CanvasNode extends SourceNode {
      */
     constructor(
         canvas: HTMLCanvasElement,
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         currentTime: number,
         preloadTime = 4

--- a/src/SourceNodes/hlsnode.ts
+++ b/src/SourceNodes/hlsnode.ts
@@ -17,7 +17,7 @@ export class HLSNode extends MediaNode {
     constructor(
         id: string,
         src: string,
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         currentTime: number,
         globalPlaybackRate = 1.0,

--- a/src/SourceNodes/imagenode.ts
+++ b/src/SourceNodes/imagenode.ts
@@ -14,7 +14,7 @@ class ImageNode extends SourceNode {
      */
     constructor(
         src: string | HTMLImageElement | ImageBitmap,
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         currentTime: number,
         preloadTime = 4,

--- a/src/SourceNodes/medianode.ts
+++ b/src/SourceNodes/medianode.ts
@@ -29,7 +29,7 @@ class MediaNode extends SourceNode {
      */
     constructor(
         src: any,
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         currentTime: number,
         globalPlaybackRate = 1.0,

--- a/src/SourceNodes/sourcenode.ts
+++ b/src/SourceNodes/sourcenode.ts
@@ -37,7 +37,7 @@ export abstract class SourceNode extends GraphNode {
      */
     constructor(
         src: any,
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         currentTime: number
     ) {

--- a/src/graphnode.ts
+++ b/src/graphnode.ts
@@ -10,7 +10,6 @@ class GraphNode {
     _renderGraph: RenderGraph;
     _destroyed: boolean;
     _gl: WebGL2RenderingContext;
-    _rendered: boolean;
     _displayName: string;
     _needsRender: boolean;
     /**
@@ -30,7 +29,6 @@ class GraphNode {
         //Setup WebGL output texture
         this._gl = gl;
         this._renderGraph = renderGraph;
-        this._rendered = false;
         this._displayName = TYPE;
         this._needsRender = false;
     }

--- a/src/graphnode.ts
+++ b/src/graphnode.ts
@@ -9,7 +9,7 @@ class GraphNode {
     _inputNames: string[];
     _renderGraph: RenderGraph;
     _destroyed: boolean;
-    _gl: WebGLRenderingContext;
+    _gl: WebGL2RenderingContext;
     _rendered: boolean;
     _displayName: string;
     _needsRender: boolean;
@@ -17,7 +17,7 @@ class GraphNode {
      * Base class from which all processing and source nodes are derrived.
      */
     constructor(
-        gl: WebGLRenderingContext,
+        gl: WebGL2RenderingContext,
         renderGraph: RenderGraph,
         inputNames: string[],
         limitConnections = false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,14 +17,18 @@ import { EFFECTTYPE } from "./ProcessingNodes/effectnode";
 /*
  * Utility function to compile a WebGL Vertex or Fragment shader.
  *
- * @param {WebGLRenderingContext} gl - the webgl context fo which to build the shader.
+ * @param {WebGL2RenderingContext} gl - the webgl context fo which to build the shader.
  * @param {String} shaderSource - A string of shader code to compile.
- * @param {number} shaderType - Shader type, either WebGLRenderingContext.VERTEX_SHADER or WebGLRenderingContext.FRAGMENT_SHADER.
+ * @param {number} shaderType - Shader type, either WebGL2RenderingContext.VERTEX_SHADER or WebGL2RenderingContext.FRAGMENT_SHADER.
  *
  * @return {WebGLShader} A compiled shader.
  *
  */
-export function compileShader(gl: WebGLRenderingContext, shaderSource: string, shaderType: number) {
+export function compileShader(
+    gl: WebGL2RenderingContext,
+    shaderSource: string,
+    shaderType: number
+) {
     let shader = gl.createShader(shaderType)!;
     gl.shaderSource(shader, shaderSource);
     gl.compileShader(shader);
@@ -38,14 +42,14 @@ export function compileShader(gl: WebGLRenderingContext, shaderSource: string, s
 /*
  * Create a shader program from a passed vertex and fragment shader source string.
  *
- * @param {WebGLRenderingContext} gl - the webgl context fo which to build the shader.
+ * @param {WebGL2RenderingContext} gl - the webgl context fo which to build the shader.
  * @param {WebGLShader} vertexShader - A compiled vertex shader.
  * @param {WebGLShader} fragmentShader - A compiled fragment shader.
  *
  * @return {WebGLProgram} A compiled & linkde shader program.
  */
 export function createShaderProgram(
-    gl: WebGLRenderingContext,
+    gl: WebGL2RenderingContext,
     vertexShader: WebGLShader,
     fragmentShader: WebGLShader
 ) {
@@ -67,8 +71,8 @@ export function createShaderProgram(
     return program;
 }
 
-export function createElementTexture(gl: WebGLRenderingContext) {
-    let texture = gl.createTexture();
+export function createElementTexture(gl: WebGL2RenderingContext) {
+    const texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     // Set the parameters so we can render any size image.
@@ -76,14 +80,14 @@ export function createElementTexture(gl: WebGLRenderingContext) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    //Initialise the texture untit to clear.
+    //Initialise the texture unit to clear.
     //gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, type);
 
     return texture;
 }
 
 export function updateTexture(
-    gl: WebGLRenderingContext,
+    gl: WebGL2RenderingContext,
     texture: WebGLTexture,
     element: HTMLImageElement | ImageBitmap | HTMLCanvasElement | HTMLVideoElement
 ) {
@@ -99,7 +103,7 @@ export function updateTexture(
     texture._isTextureCleared = false;
 }
 
-export function clearTexture(gl: WebGLRenderingContext, texture: WebGLTexture) {
+export function clearTexture(gl: WebGL2RenderingContext, texture: WebGLTexture) {
     // A quick check to ensure we don't call 'texImage2D' when the texture has already been 'cleared' #performance
     if (!texture._isTextureCleared) {
         gl.bindTexture(gl.TEXTURE_2D, texture);

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -95,7 +95,7 @@ export default class VideoContext {
 
     _canvas: HTMLCanvasElement;
     _endOnLastSourceEnd: boolean;
-    _gl: WebGLRenderingContext;
+    _gl: WebGL2RenderingContext;
     _useVideoElementCache!: boolean;
     _videoElementCache!: VideoElementCache;
     _id!: string;
@@ -153,13 +153,13 @@ export default class VideoContext {
         this._renderNodeOnDemandOnly = renderNodeOnDemandOnly;
 
         this._gl = canvas.getContext(
-            "experimental-webgl",
+            "webgl2",
             Object.assign(
                 { preserveDrawingBuffer: true }, // can be overriden
                 webglContextAttributes,
-                { alpha: false } // Can't be overriden because it is copied last
+                { alpha: true } // Can't be overriden because it is copied last
             )
-        ) as WebGLRenderingContext;
+        ) as WebGL2RenderingContext;
         if (this._gl === null) {
             console.error("Failed to intialise WebGL.");
             if (initErrorCallback) initErrorCallback();
@@ -505,6 +505,7 @@ export default class VideoContext {
      * ctx.play();
      */
     play() {
+        if (this._state === VideoContext.STATE.PLAYING) return false;
         console.debug("VideoContext - playing");
         //Initialise the video element cache
         if (this._videoElementCache) this._videoElementCache.init();
@@ -527,9 +528,15 @@ export default class VideoContext {
      * setTimeout(() => ctx.pause(), 1000); //pause playback after roughly one second.
      */
     pause() {
+        if (this._state === VideoContext.STATE.PAUSED) return false;
+
         console.debug("VideoContext - pausing");
         this._state = VideoContext.STATE.PAUSED;
         return true;
+    }
+
+    clearCanvas() {
+        this._gl.clear(this._gl.COLOR_BUFFER_BIT);
     }
 
     /**
@@ -818,7 +825,7 @@ export default class VideoContext {
         CustomSourceNode: {
             new (
                 src: any,
-                gl: WebGLRenderingContext,
+                gl: WebGL2RenderingContext,
                 renderGraph: RenderGraph,
                 currentTime: number,
                 ...args: T

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1164,7 +1164,7 @@ export default class VideoContext {
             if (renderNodes) {
                 this._lastRenderTime = this._currentTime;
             }
-            if (this._state === VideoContext.STATE.SEEKING) {
+            if (this._state === VideoContext.STATE.SEEKING && ready) {
                 this._state = VideoContext.STATE.PAUSED;
                 this._callCallbacks(VideoContext.EVENTS.SEEKED);
             }

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1037,8 +1037,9 @@ export default class VideoContext {
                 this._state !== VideoContext.STATE.PAUSED &&
                 this._state !== VideoContext.STATE.SEEKING
             ) {
+                const wasStalled = this._state === VideoContext.STATE.STALLED;
+
                 if (this._isStalled()) {
-                    const wasStalled = this._state === VideoContext.STATE.STALLED;
                     this._state = VideoContext.STATE.STALLED;
 
                     if (!wasStalled) {
@@ -1046,6 +1047,9 @@ export default class VideoContext {
                     }
                 } else {
                     this._state = VideoContext.STATE.PLAYING;
+                    if (wasStalled) {
+                        this._callCallbacks(VideoContext.EVENTS.PLAYING);
+                    }
                 }
             }
 

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -530,7 +530,6 @@ export default class VideoContext {
 
         this._callCallbacks(VideoContext.EVENTS.PLAY);
 
-        console.debug("VideoContext - playing");
         //Initialise the video element cache
         if (this._videoElementCache) this._videoElementCache.init();
         // set the state.
@@ -565,8 +564,6 @@ export default class VideoContext {
             return false;
 
         this._callCallbacks(VideoContext.EVENTS.PAUSE);
-
-        console.debug("VideoContext - pausing");
         this._state = VideoContext.STATE.PAUSED;
 
         this._runAfterNextRender = () => {
@@ -1041,8 +1038,12 @@ export default class VideoContext {
                 this._state !== VideoContext.STATE.SEEKING
             ) {
                 if (this._isStalled()) {
+                    const wasStalled = this._state === VideoContext.STATE.STALLED;
                     this._state = VideoContext.STATE.STALLED;
-                    this._callCallbacks(VideoContext.EVENTS.STALLED);
+
+                    if (!wasStalled) {
+                        this._callCallbacks(VideoContext.EVENTS.STALLED);
+                    }
                 } else {
                     this._state = VideoContext.STATE.PLAYING;
                 }

--- a/test/unit/sourcenode.spec.js
+++ b/test/unit/sourcenode.spec.js
@@ -13,7 +13,7 @@ const mockRenderGraph = {};
 
 beforeEach(() => {
     const canvas = new HTMLCanvasElement(500, 500);
-    mockGLContext = canvas.getContext("webgl");
+    mockGLContext = canvas.getContext("webgl2");
 });
 
 describe("_update", () => {

--- a/test/unit/sourcenode.spec.js
+++ b/test/unit/sourcenode.spec.js
@@ -13,7 +13,7 @@ const mockRenderGraph = {};
 
 beforeEach(() => {
     const canvas = new HTMLCanvasElement(500, 500);
-    mockGLContext = canvas.getContext("webgl2");
+    mockGLContext = canvas.getContext("webgl");
 });
 
 describe("_update", () => {


### PR DESCRIPTION
- Upgrade to webgl2
- Upgrade COMBINE and aaf_video_scale shaders to es300 -- we can upgrade the others when we're using them and can validate the changes.
- Add a new state `VideoContext.STATE.SEEKING` -- VC will be in the state when we're waiting for the current time to change after current time has been changed NOTE: vc will only enter this state from PAUSED.
- VC will return to the PAUSED state from SEEKING, once
- Add some new events `SEEKING` and `SEEKED` to be sent when the seeking and paused states are reached (ie after the video frame has rendered.
- All so add 'PAUSE', 'PAUSED' and 'PLAY', 'PLAYING' events.
- Add a clearCanvas method
- Change the rendering loop to always call render on the destinationNode -- this appears to fix some of the initial black frame errors, and also appears to speed up rendering after a seek.
- Remove the clear command from DestinationNode, and instead clear the buffer at the beginning of the render actions.

Misc changes:
- Remove _rendered prop -- it was unused
- Remove _renderPaused prop -- it was also mostly unused.
- Avoid calling pause or play when already in that state.
