### PR TITLE
Pause and unload when a node moves to the sequenced STATE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.60.2",
+  "version": "0.60.3",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/SourceNodes/medianode.ts
+++ b/src/SourceNodes/medianode.ts
@@ -305,6 +305,10 @@ class MediaNode extends SourceNode {
                 this._unload();
             }
             return false;
+        } else if (this._state === SOURCENODESTATE.sequenced && this._element !== undefined) {
+            this._element.pause();
+            this._unload();
+            return false;
         }
     }
 


### PR DESCRIPTION
If you seek to an earlier time (and earlier node) will a node is playing, it will enter the sequenced STATE... 
- There was a bug in MediaNode -- the media element would continue to play if you seeked back to a previous clip (this was only noticeable in clips with audio).
- Bump the version.