### PR TITLE
Improve CPU Usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.60.4",
+  "version": "0.61.0",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/SourceNodes/medianode.ts
+++ b/src/SourceNodes/medianode.ts
@@ -266,6 +266,11 @@ class MediaNode extends SourceNode {
         }
     }
 
+    _pause() {
+        super._pause();
+        if (this._element !== undefined) this._element.pause();
+    }
+
     _update(currentTime: number, triggerTextureUpdate = true): boolean | void {
         //if (!super._update(currentTime)) return false;
         super._update(currentTime, triggerTextureUpdate);

--- a/src/SourceNodes/medianode.ts
+++ b/src/SourceNodes/medianode.ts
@@ -268,7 +268,7 @@ class MediaNode extends SourceNode {
 
     _pause() {
         super._pause();
-        if (this._element !== undefined) this._element.pause();
+        if (this._element !== undefined && !this._element.paused) this._element.pause();
     }
 
     _update(currentTime: number, triggerTextureUpdate = true): boolean | void {

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1175,9 +1175,9 @@ export default class VideoContext {
             }
 
             for (let node of sortedNodes) {
-                if (node instanceof DestinationNode) {
-                    continue;
-                }
+                // if (node instanceof DestinationNode) {
+                //     continue;
+                // }
                 if (renderNodes && (node instanceof SourceNode || node instanceof ProcessingNode)) {
                     node._update(this._currentTime);
                 }
@@ -1199,8 +1199,8 @@ export default class VideoContext {
 
             // after nodes are rendered
             // update the previous time
-            if (renderNodes || this._lastRenderTime === undefined) {
-                this._destinationNode._render();
+            if (renderNodes) {
+                // this._destinationNode._render();
                 this._lastRenderTime = this._currentTime;
             }
             if (this._state === VideoContext.STATE.SEEKING && ready) {

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1197,10 +1197,10 @@ export default class VideoContext {
                 }
             }
 
-            this._destinationNode._render();
             // after nodes are rendered
             // update the previous time
-            if (renderNodes) {
+            if (renderNodes || this._lastRenderTime === undefined) {
+                this._destinationNode._render();
                 this._lastRenderTime = this._currentTime;
             }
             if (this._state === VideoContext.STATE.SEEKING && ready) {

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1180,9 +1180,6 @@ export default class VideoContext {
             }
 
             for (let node of sortedNodes) {
-                // if (node instanceof DestinationNode) {
-                //     continue;
-                // }
                 if (renderNodes && (node instanceof SourceNode || node instanceof ProcessingNode)) {
                     node._update(this._currentTime);
                 }
@@ -1205,7 +1202,6 @@ export default class VideoContext {
             // after nodes are rendered
             // update the previous time
             if (renderNodes) {
-                // this._destinationNode._render();
                 this._lastRenderTime = this._currentTime;
             }
             if (this._state === VideoContext.STATE.SEEKING && ready) {

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1025,6 +1025,17 @@ export default class VideoContext {
             if (!processingNode.destroyed) return processingNode;
         });
 
+        const ready = !this._isStalled();
+        const needsRender =
+            this._sourceNodes.some((node) => node.needsRender) ||
+            this._processingNodes.some((node) => node.needsRender);
+        const timeChanged = this._lastRenderTime !== this._currentTime;
+        const renderNodes = ready && (needsRender || timeChanged) && this._renderNodeOnDemandOnly;
+
+        if (this._state === VideoContext.STATE.PAUSED && !renderNodes) {
+            return;
+        }
+
         if (
             this._state === VideoContext.STATE.PLAYING ||
             this._state === VideoContext.STATE.STALLED ||
@@ -1162,12 +1173,6 @@ export default class VideoContext {
                     }
                 }
             }
-
-            const ready = !this._isStalled();
-            const needsRender = sortedNodes.some((node) => node.needsRender);
-            const timeChanged = this._lastRenderTime !== this._currentTime;
-            const renderNodes =
-                ready && (needsRender || timeChanged) && this._renderNodeOnDemandOnly;
 
             if (renderNodes) {
                 this._gl.clearColor(0, 0, 0, 0.0);


### PR DESCRIPTION
Before: 
<img width="868" alt="Screenshot 2023-11-03 at 11 20 12 am" src="https://github.com/alanjrogers/VideoContext/assets/22635/b67cad51-5e4d-4d36-9dab-02911af91552">

After:
<img width="868" alt="Screenshot 2023-11-03 at 11 29 51 am" src="https://github.com/alanjrogers/VideoContext/assets/22635/d72d9632-0b40-44e6-ad3c-623a4a808746">

It also drops to zero when the tab isn't visible -- I'm not sure if this was the case previously.

Biggest change that contributes to the improvement is that we no longer continuosly send UPDATE events when the video is paused -- only the first render (and if the nodes get marked as needing render)