### PR TITLE
Undo some CPU perf changes -- also fix preloading.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/SourceNodes/medianode.ts
+++ b/src/SourceNodes/medianode.ts
@@ -314,13 +314,11 @@ class MediaNode extends SourceNode {
                 this._unload();
             }
             return false;
-        } else if (
-            this._state === SOURCENODESTATE.sequenced &&
-            this._element !== undefined &&
-            !this._isInPreloadWindow
-        ) {
+        } else if (this._state === SOURCENODESTATE.sequenced && this._element !== undefined) {
             this._element.pause();
-            this._unload();
+            if (!this._isInPreloadWindow) {
+                this._unload();
+            }
             return false;
         }
     }

--- a/src/videocontext.ts
+++ b/src/videocontext.ts
@@ -1063,22 +1063,15 @@ export default class VideoContext {
         const timeChanged = this._lastRenderTime !== this._currentTime;
         const renderNodes = ready && (needsRender || timeChanged) && this._renderNodeOnDemandOnly;
 
-        if (this._state === VideoContext.STATE.PAUSED && !renderNodes) {
-            // Just do this but nothing else
-            const playingNodes = this._sourceNodes.filter(
-                (node) => node._state === SOURCENODESTATE.playing
-            );
-            playingNodes.forEach((node) => node._pause());
-            return;
-        }
-
         if (
             this._state === VideoContext.STATE.PLAYING ||
             this._state === VideoContext.STATE.STALLED ||
             this._state === VideoContext.STATE.PAUSED ||
             this._state === VideoContext.STATE.SEEKING
         ) {
-            this._callCallbacks(VideoContext.EVENTS.UPDATE);
+            if (this._state !== VideoContext.STATE.PAUSED) {
+                this._callCallbacks(VideoContext.EVENTS.UPDATE);
+            }
 
             if (
                 this._state !== VideoContext.STATE.PAUSED &&


### PR DESCRIPTION
- Don't skip the whole update method
- Just don't send UPDATE when the video is paused so we're not running React rendered for every RAF frame when paused.
- CPU usage is a little lower, but it's not as great as the ~10% we had before this, but at least we're not skipping over some important update calls that may be breaking a few things.
- 